### PR TITLE
feat: add support for AzureSQL to AzureSQL

### DIFF
--- a/metadata_store_scripts/V2024.10.16.0__add_azuresql_to_azuresql_support.sql
+++ b/metadata_store_scripts/V2024.10.16.0__add_azuresql_to_azuresql_support.sql
@@ -1,0 +1,36 @@
+DELETE FROM adf_type_mapping WHERE dataset = 'AZURESQL';
+
+INSERT INTO adf_type_mapping(dataset, dataset_type, adf_type)
+   VALUES
+('AZURESQL', 'tinyint', 'integer'),
+('AZURESQL', 'smallint', 'short'),
+('AZURESQL', 'int', 'integer'),
+('AZURESQL', 'bigint', 'long'),
+('AZURESQL', 'bit', 'boolean'),
+('AZURESQL', 'decimal', 'decimal'),
+('AZURESQL', 'numeric', 'decimal'),
+('AZURESQL', 'money', 'decimal'),
+('AZURESQL', 'smallmoney', 'decimal'),
+('AZURESQL', 'float', 'double'),
+('AZURESQL', 'real', 'float'),
+('AZURESQL', 'date', 'date'),
+('AZURESQL', 'time', 'timestamp'),
+('AZURESQL', 'datetime2', 'timestamp'),
+('AZURESQL', 'datetimeoffset', 'string'),
+('AZURESQL', 'datetime', 'timestamp'),
+('AZURESQL', 'smalldatetime', 'timestamp'),
+('AZURESQL', 'char', 'string'),
+('AZURESQL', 'varchar', 'string'),
+('AZURESQL', 'text', 'string'),
+('AZURESQL', 'nchar', 'string'),
+('AZURESQL', 'nvarchar', 'string'),
+('AZURESQL', 'ntext', 'string'),
+('AZURESQL', 'binary', 'binary'),
+('AZURESQL', 'varbinary', 'binary'),
+('AZURESQL', 'image', 'binary'),
+('AZURESQL', 'geography', 'binary'),
+('AZURESQL', 'geometry', 'binary'),
+('AZURESQL', 'json', 'string'),
+('AZURESQL', 'uniqueidentifier', 'string'),
+('AZURESQL', 'xml', 'string')
+;

--- a/metadata_store_scripts/V2024.10.16.0__add_azuresql_to_azuresql_support.sql
+++ b/metadata_store_scripts/V2024.10.16.0__add_azuresql_to_azuresql_support.sql
@@ -28,8 +28,6 @@ INSERT INTO adf_type_mapping(dataset, dataset_type, adf_type)
 ('AZURESQL', 'binary', 'binary'),
 ('AZURESQL', 'varbinary', 'binary'),
 ('AZURESQL', 'image', 'binary'),
-('AZURESQL', 'geography', 'binary'),
-('AZURESQL', 'geometry', 'binary'),
 ('AZURESQL', 'json', 'string'),
 ('AZURESQL', 'uniqueidentifier', 'string'),
 ('AZURESQL', 'xml', 'string')

--- a/metadata_store_scripts/bootstrap.sql
+++ b/metadata_store_scripts/bootstrap.sql
@@ -272,3 +272,40 @@ BEGIN
 END;
 -- source: V2024.08.25.0__add_conditional_masking_support
 ALTER TABLE discovered_ruleset ALTER COLUMN assigned_algorithm VARCHAR(MAX);
+-- source: V2024.10.16.0__add_azuresql_to_azuresql_support
+DELETE FROM adf_type_mapping WHERE dataset = 'AZURESQL';
+
+INSERT INTO adf_type_mapping(dataset, dataset_type, adf_type)
+   VALUES
+('AZURESQL', 'tinyint', 'integer'),
+('AZURESQL', 'smallint', 'short'),
+('AZURESQL', 'int', 'integer'),
+('AZURESQL', 'bigint', 'long'),
+('AZURESQL', 'bit', 'boolean'),
+('AZURESQL', 'decimal', 'decimal'),
+('AZURESQL', 'numeric', 'decimal'),
+('AZURESQL', 'money', 'decimal'),
+('AZURESQL', 'smallmoney', 'decimal'),
+('AZURESQL', 'float', 'double'),
+('AZURESQL', 'real', 'float'),
+('AZURESQL', 'date', 'date'),
+('AZURESQL', 'time', 'timestamp'),
+('AZURESQL', 'datetime2', 'timestamp'),
+('AZURESQL', 'datetimeoffset', 'string'),
+('AZURESQL', 'datetime', 'timestamp'),
+('AZURESQL', 'smalldatetime', 'timestamp'),
+('AZURESQL', 'char', 'string'),
+('AZURESQL', 'varchar', 'string'),
+('AZURESQL', 'text', 'string'),
+('AZURESQL', 'nchar', 'string'),
+('AZURESQL', 'nvarchar', 'string'),
+('AZURESQL', 'ntext', 'string'),
+('AZURESQL', 'binary', 'binary'),
+('AZURESQL', 'varbinary', 'binary'),
+('AZURESQL', 'image', 'binary'),
+('AZURESQL', 'geography', 'binary'),
+('AZURESQL', 'geometry', 'binary'),
+('AZURESQL', 'json', 'string'),
+('AZURESQL', 'uniqueidentifier', 'string'),
+('AZURESQL', 'xml', 'string')
+;

--- a/metadata_store_scripts/bootstrap.sql
+++ b/metadata_store_scripts/bootstrap.sql
@@ -303,8 +303,6 @@ INSERT INTO adf_type_mapping(dataset, dataset_type, adf_type)
 ('AZURESQL', 'binary', 'binary'),
 ('AZURESQL', 'varbinary', 'binary'),
 ('AZURESQL', 'image', 'binary'),
-('AZURESQL', 'geography', 'binary'),
-('AZURESQL', 'geometry', 'binary'),
 ('AZURESQL', 'json', 'string'),
 ('AZURESQL', 'uniqueidentifier', 'string'),
 ('AZURESQL', 'xml', 'string')


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

In order to support AzureSQL to AzureSQL masking, we need to add type mappings from Azure SQL data types to ADF data types.

</details>


<details open>
<summary><h2> Solution </h2></summary>

1. Wrote a migration script that will add type mappings from Azure SQL data types to ADF data types in `adf_type_mappings` table.
2. Excluded the following types since we cannot mask them - `table`, `cursor`, `sql_variant`, `hierarchyid`, `rowversion`

</details>


<details>
<summary><h2> Testing Done </h2></summary>

Verified the mappings via Projection:

<img width="1006" alt="Screenshot 2024-10-14 at 5 31 30 PM" src="https://github.com/user-attachments/assets/0a0026f7-9e16-436a-8e50-41cbdf86e836">

<img width="1007" alt="Screenshot 2024-10-14 at 5 31 50 PM" src="https://github.com/user-attachments/assets/ca1dabfe-67bf-44eb-aee2-c2a0f70c2a1b">


</details>

