### PR TITLE
Fix: Normalize column names

### DIFF
--- a/dcsazure_AzureSQL_to_AzureSQL_mask_pl/README.md
+++ b/dcsazure_AzureSQL_to_AzureSQL_mask_pl/README.md
@@ -124,3 +124,6 @@ exists, but no algorithms have been defined (default `false`)
 * `P_SINK_DATABASE` - String - This is the sink database in AzureSQL that will serve as a destination for masked data
 * `P_SOURCE_SCHEMA` - String - This is the schema within the above source database that we will mask
 * `P_SINK_SCHEMA` - String - This is the schema within the above sink database where we will place masked data
+* `P_COLUMN_NAME_NORMALIZATION_PLACEHOLDER` - String - For column names containing spaces, this placeholder will be used to normalize the column names.
+  Spaces will be replaced with this placeholder when reading from the source. Before writing back to source we de-normalize the normalized column name to
+  its original name.

--- a/dcsazure_AzureSQL_to_AzureSQL_mask_pl/dcsazure_AzureSQL_to_AzureSQL_mask_pl.json
+++ b/dcsazure_AzureSQL_to_AzureSQL_mask_pl/dcsazure_AzureSQL_to_AzureSQL_mask_pl.json
@@ -139,7 +139,11 @@
                                 "type": "Expression"
                               },
                               "DF_COLUMN_WIDTH_ESTIMATE": "1000",
-                              "DF_DATASET": "'AZURESQL'"
+                              "DF_DATASET": "'AZURESQL'",
+                              "DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER": {
+                                "value": "'@{pipeline().parameters.P_COLUMN_NAME_NORMALIZATION_PLACEHOLDER}'",
+                                "type": "Expression"
+                              }
                             },
                             "datasetParameters": {
                               "Ruleset": {},
@@ -225,6 +229,10 @@
                               },
                               "DF_FIELD_DATE_FORMAT": {
                                 "value": "'@{activity('Get Masking Parameters No Filter').output.runStatus.output.MaskingParameterOutput.value[0].DateFormatAssignments}'",
+                                "type": "Expression"
+                              },
+                              "DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER": {
+                                "value": "'@{pipeline().parameters.P_COLUMN_NAME_NORMALIZATION_PLACEHOLDER}'",
                                 "type": "Expression"
                               }
                             },
@@ -622,6 +630,10 @@
                               "DF_DATASET": {
                                 "value": "'@{item().source_dataset}'",
                                 "type": "Expression"
+                              },
+                              "DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER": {
+                                "value": "'@{pipeline().parameters.P_COLUMN_NAME_NORMALIZATION_PLACEHOLDER}'",
+                                "type": "Expression"
                               }
                             },
                             "datasetParameters": {
@@ -712,6 +724,10 @@
                               },
                               "DF_FILTER_CONDITION": {
                                 "value": "@item().filter_value",
+                                "type": "Expression"
+                              },
+                              "DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER": {
+                                "value": "'@{pipeline().parameters.P_COLUMN_NAME_NORMALIZATION_PLACEHOLDER}'",
                                 "type": "Expression"
                               }
                             },
@@ -2366,6 +2382,10 @@
           "P_TRUNCATE_SINK_BEFORE_WRITE": {
             "type": "bool",
             "defaultValue": true
+          },
+          "P_COLUMN_NAME_NORMALIZATION_PLACEHOLDER": {
+            "type": "string",
+            "defaultValue": "__$__"
           }
         },
         "variables": {
@@ -2404,7 +2424,7 @@
         },
         "folder": { "name": "dcsazure_AzureSQL_to_AzureSQL" },
         "annotations": [],
-        "lastPublishTime": "2024-12-17T07:17:03Z"
+        "lastPublishTime": "2025-01-02T10:39:35Z"
       },
       "dependsOn": [
         "[concat(variables('factoryId'), '/datasets/dcsazure_AzureSQL_to_AzureSQL_mask_metadata_ds')]",
@@ -3060,7 +3080,7 @@
         },
         "folder": { "name": "dcsazure_AzureSQL_to_AzureSQL" },
         "annotations": [],
-        "lastPublishTime": "2024-12-17T07:17:03Z"
+        "lastPublishTime": "2025-01-02T10:39:34Z"
       },
       "dependsOn": [
         "[concat(variables('factoryId'), '/datasets/dcsazure_AzureSQL_to_AzureSQL_mask_sink_ds')]",
@@ -3453,7 +3473,7 @@
         },
         "folder": { "name": "dcsazure_AzureSQL_to_AzureSQL" },
         "annotations": [],
-        "lastPublishTime": "2024-12-16T18:00:25Z"
+        "lastPublishTime": "2025-01-02T10:39:34Z"
       },
       "dependsOn": [
         "[concat(variables('factoryId'), '/datasets/dcsazure_AzureSQL_to_AzureSQL_mask_sink_ds')]",
@@ -3591,7 +3611,8 @@
             "     DF_SOURCE_SCHEMA as string (''),",
             "     DF_SOURCE_TABLE as string (''),",
             "     DF_COLUMN_WIDTH_ESTIMATE as integer (1000),",
-            "     DF_DATASET as string ('AZURESQL')",
+            "     DF_DATASET as string ('AZURESQL'),",
+            "     DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER as string ('__$__')",
             "}",
             "source(output(",
             "          dataset as string,",
@@ -3642,13 +3663,13 @@
             "     ignoreSpaces: false,",
             "     broadcast: 'left')~> RulesetWithTypes",
             "RulesetWithTypes derive(output_row = 1,",
-            "          adf_type_conversion = concat(identified_column, ' as ', adf_type),",
+            "          adf_type_conversion = concat(replace(identified_column, ' ', $DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER), ' as ', adf_type),",
             "          column_width_estimate = iif(identified_column_max_length > 0, identified_column_max_length+4, $DF_COLUMN_WIDTH_ESTIMATE)) ~> RulesetWithAlgorithmTypeMapping",
             "RulesetWithAlgorithmTypeMapping aggregate(groupBy(output_row),",
-            "     FieldAlgorithmAssignments = regexReplace(reduce(mapAssociation(keyValues(collect(identified_column), collect(assigned_algorithm)), '\"' + #key + '\":\"' + #value + '\"'), '{', #acc + #item + ',', #result + '}'), ',}', '}'),",
-            "          ColumnsToMask = regexReplace(reduce(collect(identified_column), '[',  #acc + '\"' + #item + '\",', #result + ']'), ',]', ']'),",
+            "     FieldAlgorithmAssignments = regexReplace(reduce(mapAssociation(keyValues(collect(replace(identified_column, ' ', $DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER)), collect(assigned_algorithm)), '\"' + #key + '\":\"' + #value + '\"'), '{', #acc + #item + ',', #result + '}'), ',}', '}'),",
+            "          ColumnsToMask = regexReplace(reduce(collect(replace(identified_column, ' ', $DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER)), '[',  #acc + '\"' + #item + '\",', #result + ']'), ',]', ']'),",
             "          DataFactoryTypeMapping = concat(\"'\", '(timestamp as date, status as string, message as string, trace_id as string, items as (DELPHIX_COMPLIANCE_SERVICE_BATCH_ID as long, ',",
-            "    regexReplace(reduce(collect(identified_column + ' as ' + adf_type), '', #acc + #item + ', ', #result + ')'), ', \\\\)', ')'),",
+            "    regexReplace(reduce(collect(replace(identified_column, ' ', $DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER)  + ' as ' + adf_type), '', #acc + #item + ', ', #result + ')'), ', \\\\)', ')'),",
             "    '[])', \"'\"),",
             "          NumberOfBatches = toInteger(ceil(((max(row_count) * (sum(column_width_estimate) + log10(max(row_count)) +1)) / (2000000 * .9)))),",
             "          TrimLengths = regexReplace(reduce(collect(identified_column_max_length), '[',  #acc + toString(#item) + ',', toString(#result) + ']'), ',]', ']')) ~> GenerateMaskParameters",
@@ -3774,6 +3795,10 @@
             {
               "name": "TrimMaskedStrings",
               "description": "For each column with a string type, trim the string to length based on the value in DF_TRIM_LENGTHS - this is needed as masking a string may produce a longer string that exceeds the column width in the sink"
+            },
+            {
+              "name": "NormalizeColumnNames",
+              "description": "Normalize all column names with spaces with the normalization placeholder"
             }
           ],
           "scriptLines": [
@@ -3789,7 +3814,8 @@
             "     DF_NUMBER_OF_ROWS_PER_BATCH as integer (1000),",
             "     DF_TRIM_LENGTHS as integer[] ([1000]),",
             "     DF_FAIL_ON_NONCONFORMANT_DATA as boolean (true()),",
-            "     DF_FIELD_DATE_FORMAT as string ('{}')",
+            "     DF_FIELD_DATE_FORMAT as string ('{}'),",
+            "     DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER as string ('__$__')",
             "}",
             "source(allowSchemaDrift: true,",
             "     validateSchema: false,",
@@ -3824,7 +3850,7 @@
             "     requestFormat: ['type' -> 'json'],",
             "     responseFormat: ['type' -> 'json', 'documentForm' -> 'documentPerLine'],",
             "     columnTypeMap: ['body'->'$DF_BODY_TYPE_MAPPING']) ~> DCSForAzureAPI",
-            "Source derive(DELPHIX_COMPLIANCE_SERVICE_SORT_ID = sha2(256, columns())) ~> AddSortKey",
+            "NormalizeColumnNames derive(DELPHIX_COMPLIANCE_SERVICE_SORT_ID = sha2(256, columns())) ~> AddSortKey",
             "AddSortKey sort(asc(DELPHIX_COMPLIANCE_SERVICE_SORT_ID, false)) ~> SortBySortKey",
             "SortBySortKey keyGenerate(output(DELPHIX_COMPLIANCE_SERVICE_BATCH_ID as long),",
             "     startAt: 1L,",
@@ -3856,6 +3882,12 @@
             "    substring($$, 1, $DF_TRIM_LENGTHS[toInteger($# - 1)]), ",
             "    $$",
             "))) ~> TrimMaskedStrings",
+            "Source select(mapColumn(",
+            "          each(match(true()),",
+            "               replace($$,' ',$DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER) = $$)",
+            "     ),",
+            "     skipDuplicateMapInputs: true,",
+            "     skipDuplicateMapOutputs: true) ~> NormalizeColumnNames",
             "JoinMaskedAndUnmaskedData sink(allowSchemaDrift: true,",
             "     validateSchema: false,",
             "     format: 'table',",
@@ -3872,7 +3904,8 @@
             "     skipDuplicateMapOutputs: true,",
             "     errorHandlingOption: 'stopOnFirstError',",
             "     mapColumn(",
-            "          each(match(name!=\"DELPHIX_COMPLIANCE_SERVICE_BATCH_ID\"&&name!=\"DELPHIX_COMPLIANCE_SERVICE_SORT_ID\"))",
+            "          each(match(name!=\"DELPHIX_COMPLIANCE_SERVICE_BATCH_ID\"&&name!=\"DELPHIX_COMPLIANCE_SERVICE_SORT_ID\"),",
+            "               replace($$,$DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER,' ') = $$)",
             "     ),",
             "     preCommands: [],",
             "     postCommands: []) ~> Sink"
@@ -4035,7 +4068,8 @@
             "     DF_SOURCE_TABLE as string (''),",
             "     DF_COLUMN_WIDTH_ESTIMATE as integer (1000),",
             "     DF_FILTER_KEY as string (''),",
-            "     DF_DATASET as string ('AZURESQL')",
+            "     DF_DATASET as string ('AZURESQL'),",
+            "     DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER as string ('__$__')",
             "}",
             "source(output(",
             "          dataset as string,",
@@ -4086,13 +4120,13 @@
             "     ignoreSpaces: false,",
             "     broadcast: 'left')~> RulesetWithTypes",
             "RulesetWithTypes derive(output_row = 1,",
-            "          adf_type_conversion = concat(identified_column, ' as ', adf_type),",
+            "          adf_type_conversion = concat('\"', replace(identified_column, ' ', $DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER), '\"', ' as ', adf_type),",
             "          column_width_estimate = iif(identified_column_max_length > 0, identified_column_max_length+4, $DF_COLUMN_WIDTH_ESTIMATE)) ~> RulesetWithAlgorithmTypeMapping",
             "RulesetWithAlgorithmTypeMapping aggregate(groupBy(output_row),",
-            "     FieldAlgorithmAssignments = regexReplace(reduce(mapAssociation(keyValues(collect(identified_column), collect(assigned_algorithm)), '\"' + #key + '\":\"' + #value + '\"'), '{', #acc + #item + ',', #result + '}'), ',}', '}'),",
-            "          ColumnsToMask = regexReplace(reduce(collect(identified_column), '[',  #acc + '\"' + #item + '\",', #result + ']'), ',]', ']'),",
+            "     FieldAlgorithmAssignments = regexReplace(reduce(mapAssociation(keyValues(collect(replace(identified_column, ' ', $DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER)), collect(assigned_algorithm)), '\"' + #key + '\":\"' + #value + '\"'), '{', #acc + #item + ',', #result + '}'), ',}', '}'),",
+            "          ColumnsToMask = regexReplace(reduce(collect(replace(identified_column, ' ', $DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER)), '[',  #acc + '\"' + #item + '\",', #result + ']'), ',]', ']'),",
             "          DataFactoryTypeMapping = concat(\"'\", '(timestamp as date, status as string, message as string, trace_id as string, items as (DELPHIX_COMPLIANCE_SERVICE_BATCH_ID as long, ',",
-            "    regexReplace(reduce(collect(identified_column + ' as ' + adf_type), '', #acc + #item + ', ', #result + ')'), ', \\\\)', ')'),",
+            "    regexReplace(reduce(collect('\"' + replace(identified_column, ' ', $DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER) + '\"' + ' as ' + adf_type), '', #acc + #item + ', ', #result + ')'), ', \\\\)', ')'),",
             "    '[])', \"'\"),",
             "          NumberOfBatches = toInteger(ceil(((max(row_count) * (sum(column_width_estimate) + log10(max(row_count)) +1)) / (2000000 * .9)))),",
             "          TrimLengths = regexReplace(reduce(collect(identified_column_max_length), '[',  #acc + toString(#item) + ',', toString(#result) + ']'), ',]', ']')) ~> GenerateMaskParameters",
@@ -4329,6 +4363,10 @@
             {
               "name": "ApplyTableFilter",
               "description": "Filter base table based on supplied filter"
+            },
+            {
+              "name": "NormalizeColumnNames",
+              "description": "Normalize all column names with spaces with the normalization placeholder"
             }
           ],
           "scriptLines": [
@@ -4345,7 +4383,8 @@
             "     DF_TRIM_LENGTHS as integer[] ([1000]),",
             "     DF_FAIL_ON_NONCONFORMANT_DATA as boolean (true()),",
             "     DF_FIELD_DATE_FORMAT as string ('{}'),",
-            "     DF_FILTER_CONDITION as boolean (true())",
+            "     DF_FILTER_CONDITION as boolean (true()),",
+            "     DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER as string ('__$__')",
             "}",
             "source(allowSchemaDrift: true,",
             "     validateSchema: false,",
@@ -4412,7 +4451,13 @@
             "    substring($$, 1, $DF_TRIM_LENGTHS[toInteger($# - 1)]), ",
             "    $$",
             "))) ~> TrimMaskedStrings",
-            "Source filter($DF_FILTER_CONDITION) ~> ApplyTableFilter",
+            "NormalizeColumnNames filter($DF_FILTER_CONDITION) ~> ApplyTableFilter",
+            "Source select(mapColumn(",
+            "          each(match(true()),",
+            "               replace($$,' ',$DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER) = $$)",
+            "     ),",
+            "     skipDuplicateMapInputs: true,",
+            "     skipDuplicateMapOutputs: true) ~> NormalizeColumnNames",
             "JoinMaskedAndUnmaskedData sink(allowSchemaDrift: true,",
             "     validateSchema: false,",
             "     format: 'table',",
@@ -4429,7 +4474,8 @@
             "     skipDuplicateMapOutputs: true,",
             "     errorHandlingOption: 'stopOnFirstError',",
             "     mapColumn(",
-            "          each(match(name!=\"DELPHIX_COMPLIANCE_SERVICE_BATCH_ID\"&&name!=\"DELPHIX_COMPLIANCE_SERVICE_SORT_ID\"))",
+            "          each(match(name!=\"DELPHIX_COMPLIANCE_SERVICE_BATCH_ID\"&&name!=\"DELPHIX_COMPLIANCE_SERVICE_SORT_ID\"),",
+            "               replace($$,$DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER,' ') = $$)",
             "     ),",
             "     preCommands: [],",
             "     postCommands: []) ~> Sink"

--- a/dcsazure_adls_to_adls_discovery_pl/README.md
+++ b/dcsazure_adls_to_adls_discovery_pl/README.md
@@ -75,10 +75,10 @@ have customized your metadata store, then these variables may need editing.
   accept, in part, the file structure from the `Get Metadata` ADF pipeline Activity.
 * `HETEROGENEOUS_SCHEMAS_TO_CHECK` - This variable is modified during execution of the pipeline, and serves as an
   accumulator for the list of directories with heterogeneous schemas (default `[]` - do not modify).
-* `HETEROGENEOUS_SCHEMAS_TO_CHECK` - This variable is modified during execution of the pipeline, and serves as an
+* `HOMOGENEOUS_SCHEMAS_TO_CHECK` - This variable is modified during execution of the pipeline, and serves as an
   accumulator for the list of directories with homogeneous schemas (default `[]` - do not modify).
 * `DATASET` - This is used to identify data that belongs to this pipeline in the metadata store (default `ADLS`).
-* `METADATA_EVENT_PROCEDURE_NAME` - This is the name of the procedure used to capture pipeline information in the 
+* `METADATA_EVENT_PROCEDURE_NAME` - This is the name of the procedure used to capture pipeline information in the
   metadata data store and sets the discovery state on the items discovered during execution
   (default `insert_adf_discovery_event`).
 * `NUMBER_OF_ROWS_TO_PROFILE` - This is the number of rows we should select for profiling, note that raising this value
@@ -114,6 +114,9 @@ have customized your metadata store, then these variables may need editing.
   `{"DCS_EXAMPLE_PREFIX":{"suffixes":["csv","txt","NO_EXT"]}}`)
 * `P_REDISCOVER` - This is a Bool that specifies if we should re-execute the data discovery dataflow for previously
   discovered files that have not had their schema modified (default `true`)
+* `P_COLUMN_NAME_NORMALIZATION_PLACEHOLDER` - String - For column names containing spaces, this placeholder will be used to normalize the column names.
+  Spaces will be replaced with this placeholder when reading from the source. Before writing back to source we de-normalize the normalized column name to
+  its original name.
 
 
 #### Notes
@@ -216,7 +219,7 @@ directory_to_profile
     └── file2.txt
 ```
 
-In order to correctly profile, we'd have to specify `P_SUB_DIRECTORY_WITH_MIXED_FILE_SCHEMAS` as 
+In order to correctly profile, we'd have to specify `P_SUB_DIRECTORY_WITH_MIXED_FILE_SCHEMAS` as
 `["heterogeneous_subdirectory"]` and `P_MIXED_FILE_SCHEMA_DISAMBIGUATION` as:
 ```json
 {

--- a/dcsazure_adls_to_adls_mask_pl/dcsazure_adls_to_adls_mask_pl.json
+++ b/dcsazure_adls_to_adls_mask_pl/dcsazure_adls_to_adls_mask_pl.json
@@ -198,7 +198,11 @@
                                 "value": "'@{item().source_table}'",
                                 "type": "Expression"
                               },
-                              "DF_COLUMN_WIDTH_ESTIMATE": "1000"
+                              "DF_COLUMN_WIDTH_ESTIMATE": "1000",
+                              "DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER": {
+                                "value": "'@{pipeline().parameters.P_COLUMN_NAME_NORMALIZATION_PLACEHOLDER}'",
+                                "type": "Expression"
+                              }
                             },
                             "datasetParameters": {
                               "Ruleset": {},
@@ -317,6 +321,10 @@
                               },
                               "DF_FIELD_DATE_FORMAT": {
                                 "value": "'@{activity('Get Masking Parameters No Filter').output.runStatus.output.MaskingParameterOutput.value[0].DateFormatAssignments}'",
+                                "type": "Expression"
+                              },
+                              "DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER": {
+                                "value": "'@{pipeline().parameters.P_COLUMN_NAME_NORMALIZATION_PLACEHOLDER}'",
                                 "type": "Expression"
                               }
                             },
@@ -738,6 +746,10 @@
                               "DF_DATASET": {
                                 "value": "'@{variables('DATASET')}'",
                                 "type": "Expression"
+                              },
+                              "DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER": {
+                                "value": "'@{pipeline().parameters.P_COLUMN_NAME_NORMALIZATION_PLACEHOLDER}'",
+                                "type": "Expression"
                               }
                             },
                             "datasetParameters": {
@@ -861,6 +873,10 @@
                               },
                               "DF_FILTER_CONDITION": {
                                 "value": "@item().filter_value",
+                                "type": "Expression"
+                              },
+                              "DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER": {
+                                "value": "'@{pipeline().parameters.P_COLUMN_NAME_NORMALIZATION_PLACEHOLDER}'",
                                 "type": "Expression"
                               }
                             },
@@ -2432,6 +2448,7 @@
                     ],
                     "storeSettings": {
                       "type": "AzureBlobFSReadSettings",
+                      "recursive": true,
                       "enablePartitionDiscovery": false
                     },
                     "formatSettings": {
@@ -2570,6 +2587,10 @@
           },
           "P_SINK_DIRECTORY": {
             "type": "string"
+          },
+          "P_COLUMN_NAME_NORMALIZATION_PLACEHOLDER": {
+            "type": "string",
+            "defaultValue": "__$__"
           }
         },
         "variables": {
@@ -2610,7 +2631,7 @@
           "name": "dcsazure_adls_to_adls"
         },
         "annotations": [],
-        "lastPublishTime": "2024-09-25T01:21:56Z"
+        "lastPublishTime": "2025-01-03T10:42:46Z"
       },
       "dependsOn": [
         "[concat(variables('factoryId'), '/datasets/dcsazure_adls_to_adls_metadata_mask_ds')]",
@@ -2978,7 +2999,8 @@
             "     DF_SOURCE_CONTAINER as string (''),",
             "     DF_SOURCE_SCHEMA as string (''),",
             "     DF_SOURCE_TABLE as string (''),",
-            "     DF_COLUMN_WIDTH_ESTIMATE as integer (1000)",
+            "     DF_COLUMN_WIDTH_ESTIMATE as integer (1000),",
+            "     DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER as string ('__$__')",
             "}",
             "source(output(",
             "          dataset as string,",
@@ -3028,14 +3050,14 @@
             "     matchType:'exact',",
             "     ignoreSpaces: false,",
             "     broadcast: 'left')~> RulesetWithTypes",
-            "RulesetWithTypes derive(adf_type_conversion = concat(identified_column, ' as ', adf_type),",
+            "RulesetWithTypes derive(adf_type_conversion = concat(replace(identified_column, ' ', $DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER), ' as ', adf_type),",
             "          output_row = 1,",
             "          column_width_estimate = iif(identified_column_max_length > 0, identified_column_max_length+4, $DF_COLUMN_WIDTH_ESTIMATE)) ~> RulesetWithAlgorithmTypeMapping",
             "RulesetWithAlgorithmTypeMapping aggregate(groupBy(output_row),",
-            "     FieldAlgorithmAssignments = regexReplace(reduce(mapAssociation(keyValues(collect(identified_column), collect(assigned_algorithm)), '\"' + #key + '\":\"' + #value + '\"'), '{', #acc + #item + ',', #result + '}'), ',}', '}'),",
-            "          ColumnsToMask = regexReplace(reduce(collect(identified_column), '[',  #acc + '\"' + #item + '\",', #result + ']'), ',]', ']'),",
+            "     FieldAlgorithmAssignments = regexReplace(reduce(mapAssociation(keyValues(collect(replace(identified_column, ' ', $DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER)), collect(assigned_algorithm)), '\"' + #key + '\":\"' + #value + '\"'), '{', #acc + #item + ',', #result + '}'), ',}', '}'),",
+            "          ColumnsToMask = regexReplace(reduce(collect(replace(identified_column, ' ', $DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER)), '[',  #acc + '\"' + #item + '\",', #result + ']'), ',]', ']'),",
             "          DataFactoryTypeMapping = concat(\"'\", '(timestamp as date, status as string, message as string, trace_id as string, items as (DELPHIX_COMPLIANCE_SERVICE_BATCH_ID as long, ',",
-            "    regexReplace(reduce(collect(identified_column + ' as ' + adf_type), '', #acc + #item + ', ', #result + ')'), ', \\\\)', ')'),",
+            "    regexReplace(reduce(collect(replace(identified_column, ' ', $DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER) + ' as ' + adf_type), '', #acc + #item + ', ', #result + ')'), ', \\\\)', ')'),",
             "    '[])', \"'\"),",
             "          NumberOfBatches = toInteger(ceil(((max(row_count) * (sum(column_width_estimate) + log10(max(row_count))+1)) / (2000000 * .9)))),",
             "          TrimLengths = regexReplace(reduce(collect(identified_column_max_length), '[',  #acc + toString(#item) + ',', toString(#result) + ']'), ',]', ']')) ~> GenerateMaskParameters",
@@ -3183,6 +3205,10 @@
             {
               "name": "RemoveAllData",
               "description": "To preserve the order of the columns, we will remove all rows from the table by filtering on false()"
+            },
+            {
+              "name": "NormalizeColumnNames",
+              "description": "Normalize all column names with spaces with the normalization placeholder"
             }
           ],
           "scriptLines": [
@@ -3205,7 +3231,8 @@
             "     DF_TRIM_LENGTHS as integer[] ([-1]),",
             "     DF_FAIL_ON_NONCONFORMANT_DATA as boolean (true()),",
             "     DF_TARGET_BATCH_SIZE as integer (2000),",
-            "     DF_FIELD_DATE_FORMAT as string ('{}')",
+            "     DF_FIELD_DATE_FORMAT as string ('{}'),",
+            "     DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER as string ('__$__')",
             "}",
             "source(useSchema: false,",
             "     allowSchemaDrift: true,",
@@ -3246,7 +3273,7 @@
             "     requestFormat: ['type' -> 'json'],",
             "     responseFormat: ['type' -> 'json', 'documentForm' -> 'documentPerLine'],",
             "     columnTypeMap: ['body'->'$DF_BODY_TYPE_MAPPING']) ~> DCSForAzureAPI",
-            "Source derive(DELPHIX_COMPLIANCE_SERVICE_SORT_ID = sha2(256, columns())) ~> AddSortKey",
+            "NormalizeColumnNames derive(DELPHIX_COMPLIANCE_SERVICE_SORT_ID = sha2(256, columns())) ~> AddSortKey",
             "AddSortKey sort(asc(DELPHIX_COMPLIANCE_SERVICE_SORT_ID, false)) ~> SortBySortKey",
             "SortBySortKey keyGenerate(output(DELPHIX_COMPLIANCE_SERVICE_BATCH_ID as long),",
             "     startAt: 1L,",
@@ -3283,6 +3310,13 @@
             "     skipDuplicateMapInputs: true,",
             "     skipDuplicateMapOutputs: true) ~> RemoveAmbiguousColumn",
             "CreateSurrogateKey filter(false()) ~> RemoveAllData",
+            "Source select(mapColumn(",
+            "          DELPHIX_COMPLIANCE_SERVICE_FILE_NAME,",
+            "          each(match(true()),",
+            "               replace($$,' ',$DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER) = $$)",
+            "     ),",
+            "     skipDuplicateMapInputs: true,",
+            "     skipDuplicateMapOutputs: true) ~> NormalizeColumnNames",
             "CreateSinkFileName sink(allowSchemaDrift: true,",
             "     validateSchema: false,",
             "     format: 'delimited',",
@@ -3300,7 +3334,8 @@
             "     skipDuplicateMapInputs: true,",
             "     skipDuplicateMapOutputs: true,",
             "     mapColumn(",
-            "          each(match(name!=\"DELPHIX_COMPLIANCE_SERVICE_BATCH_ID\"&&name!=\"DELPHIX_COMPLIANCE_SERVICE_SORT_ID\"&&name!=\"DELPHIX_COMPLIANCE_SERVICE_FILE_NAME\"))",
+            "          each(match(name!=\"DELPHIX_COMPLIANCE_SERVICE_BATCH_ID\"&&name!=\"DELPHIX_COMPLIANCE_SERVICE_SORT_ID\"&&name!=\"DELPHIX_COMPLIANCE_SERVICE_FILE_NAME\"),",
+            "               replace($$,$DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER,' ') = $$)",
             "     )) ~> Sink"
           ]
         }
@@ -3463,7 +3498,8 @@
             "     DF_SOURCE_TABLE as string (''),",
             "     DF_COLUMN_WIDTH_ESTIMATE as integer (1000),",
             "     DF_FILTER_KEY as string (''),",
-            "     DF_DATASET as string ('ADLS')",
+            "     DF_DATASET as string ('ADLS'),",
+            "     DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER as string ('__$__')",
             "}",
             "source(output(",
             "          dataset as string,",
@@ -3513,14 +3549,14 @@
             "     matchType:'exact',",
             "     ignoreSpaces: false,",
             "     broadcast: 'left')~> RulesetWithTypes",
-            "RulesetWithTypes derive(adf_type_conversion = concat(identified_column, ' as ', adf_type),",
+            "RulesetWithTypes derive(adf_type_conversion = concat(replace(identified_column, ' ', $DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER), ' as ', adf_type),",
             "          output_row = 1,",
             "          column_width_estimate = iif(identified_column_max_length > 0, identified_column_max_length+4, $DF_COLUMN_WIDTH_ESTIMATE)) ~> RulesetWithAlgorithmTypeMapping",
             "RulesetWithAlgorithmTypeMapping aggregate(groupBy(output_row),",
-            "     FieldAlgorithmAssignments = regexReplace(reduce(mapAssociation(keyValues(collect(identified_column), collect(assigned_algorithm)), '\"' + #key + '\":\"' + #value + '\"'), '{', #acc + #item + ',', #result + '}'), ',}', '}'),",
-            "          ColumnsToMask = regexReplace(reduce(collect(identified_column), '[',  #acc + '\"' + #item + '\",', #result + ']'), ',]', ']'),",
+            "     FieldAlgorithmAssignments = regexReplace(reduce(mapAssociation(keyValues(collect(replace(identified_column, ' ', $DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER)), collect(assigned_algorithm)), '\"' + #key + '\":\"' + #value + '\"'), '{', #acc + #item + ',', #result + '}'), ',}', '}'),",
+            "          ColumnsToMask = regexReplace(reduce(collect(replace(identified_column, ' ', $DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER)), '[',  #acc + '\"' + #item + '\",', #result + ']'), ',]', ']'),",
             "          DataFactoryTypeMapping = concat(\"'\", '(timestamp as date, status as string, message as string, trace_id as string, items as (DELPHIX_COMPLIANCE_SERVICE_BATCH_ID as long, ',",
-            "    regexReplace(reduce(collect(identified_column + ' as ' + adf_type), '', #acc + #item + ', ', #result + ')'), ', \\\\)', ')'),",
+            "    regexReplace(reduce(collect(replace(identified_column, ' ', $DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER) + ' as ' + adf_type), '', #acc + #item + ', ', #result + ')'), ', \\\\)', ')'),",
             "    '[])', \"'\"),",
             "          NumberOfBatches = toInteger(ceil(((max(row_count) * (sum(column_width_estimate) + log10(max(row_count))+1)) / (2000000 * .9)))),",
             "          TrimLengths = regexReplace(reduce(collect(identified_column_max_length), '[',  #acc + toString(#item) + ',', toString(#result) + ']'), ',]', ']')) ~> GenerateMaskParameters",
@@ -3780,6 +3816,10 @@
             {
               "name": "ApplyTableFilter",
               "description": "Filter base table based on supplied filter"
+            },
+            {
+              "name": "NormalizeColumnNames",
+              "description": "Normalize all column names with spaces with the normalization placeholder"
             }
           ],
           "scriptLines": [
@@ -3803,7 +3843,8 @@
             "     DF_FAIL_ON_NONCONFORMANT_DATA as boolean (true()),",
             "     DF_TARGET_BATCH_SIZE as integer (2000),",
             "     DF_FIELD_DATE_FORMAT as string ('{}'),",
-            "     DF_FILTER_CONDITION as boolean (true())",
+            "     DF_FILTER_CONDITION as boolean (true()),",
+            "     DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER as string ('__$__')",
             "}",
             "source(useSchema: false,",
             "     allowSchemaDrift: true,",
@@ -3881,7 +3922,14 @@
             "     skipDuplicateMapInputs: true,",
             "     skipDuplicateMapOutputs: true) ~> RemoveAmbiguousColumn",
             "CreateSurrogateKey filter(false()) ~> RemoveAllData",
-            "Source filter($DF_FILTER_CONDITION) ~> ApplyTableFilter",
+            "NormalizeColumnNames filter($DF_FILTER_CONDITION) ~> ApplyTableFilter",
+            "Source select(mapColumn(",
+            "          DELPHIX_COMPLIANCE_SERVICE_FILE_NAME,",
+            "          each(match(true()),",
+            "               replace($$,' ',$DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER) = $$)",
+            "     ),",
+            "     skipDuplicateMapInputs: true,",
+            "     skipDuplicateMapOutputs: true) ~> NormalizeColumnNames",
             "CreateSinkFileName sink(allowSchemaDrift: true,",
             "     validateSchema: false,",
             "     format: 'delimited',",
@@ -3899,7 +3947,8 @@
             "     skipDuplicateMapInputs: true,",
             "     skipDuplicateMapOutputs: true,",
             "     mapColumn(",
-            "          each(match(name!=\"DELPHIX_COMPLIANCE_SERVICE_BATCH_ID\"&&name!=\"DELPHIX_COMPLIANCE_SERVICE_SORT_ID\"&&name!=\"DELPHIX_COMPLIANCE_SERVICE_FILE_NAME\"))",
+            "          each(match(name!=\"DELPHIX_COMPLIANCE_SERVICE_BATCH_ID\"&&name!=\"DELPHIX_COMPLIANCE_SERVICE_SORT_ID\"&&name!=\"DELPHIX_COMPLIANCE_SERVICE_FILE_NAME\"),",
+            "               replace($$,$DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER,' ') = $$)",
             "     )) ~> Sink"
           ]
         }


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

Pipelines will fail if the source dataset/tables has column names with spaces. The body type mapping we generate will contain the column names with space and fail with syntax error. 

Example failure message

```console
Job failed due to reason: com.microsoft.dataflow.Issues: DF-DSL-001 - Expr stream  has parsing errors
Line 1 Position 157: (timestamp as date, status as string, message as string, trace_id as string, items as (DELPHIX_COMPLIANCE_SERVICE_BATCH_ID as long, Website as string, Phone 2 as string, Phone 1 as string, Last Name as string, First Name as string, Email as string, Country as string, Company as string, City as string)[])
extraneous input '2' expecting 'as'
Line 1 Position 176: (timestamp as date, status as string, message as string, trace_id as string, items as (DELPHIX_COMPLIANCE_SERVICE_BATCH_ID as long, Website as string, Phone 2 as string, Phone 1 as string, Last Name as string, First Name as string, Email as string, Country as string, Company as string, City as string)[])
extraneous input '1' expecting 'as'
Line 1 Position 194: (timestamp as date, status as string, message as string, trace_id as string, items as (DELPHIX_COMPLIANCE_SERVICE_BATCH_ID as long, Website as string, Phone 2 as string, Phone
```

Example generated masking parameter 
```json
{
    "dataflow": {
        "referenceName": "dcsazure_adls_to_adls_delimited_unfiltered_mask_df",
        "type": "DataFlowReference",
        "parameters": {
            "runId": "'2cbaac22-7923-458c-807d-ebc4174eb009'",
            "DF_SOURCE_CONTAINER": "'adls-source01'",
            "DF_SINK_CONTAINER": "'adls-target01'",
            "DF_SOURCE_DIRECTORY": "'src-dataset/customers/'",
            "DF_SINK_DIRECTORY": "'tgt/customers/'",
            "DF_SOURCE_PREFIX": "''",
            "DF_SOURCE_TABLE": "'csv'",
            "DF_SINK_TABLE": "'csv'",
            "DF_COLUMN_DELIMITER": "','",
            "DF_QUOTE_CHARACTER": "'\"'",
            "DF_ESCAPE_CHARACTER": "'\\\\'",
            "DF_NULL_VALUE": "''",
            "DF_FIELD_ALGORITHM_ASSIGNMENT": "'{\"Website\":\"WebURLsLookup\",\"Phone 2\":\"dlpx-core:Phone Unique\",\"Phone 1\":\"dlpx-core:Phone Unique\",\"Last Name\":\"dlpx-core:LastName\",\"First Name\":\"dlpx-core:FirstName\",\"Email\":\"dlpx-core:Email Unique\",\"Country\":\"dlpx-core:Countries SL\",\"Company\":\"dlpx-core:FullName\",\"City\":\"USCitiesLookup\"}'",
            "DF_COLUMNS_TO_MASK": "[\"Website\",\"Phone 2\",\"Phone 1\",\"Last Name\",\"First Name\",\"Email\",\"Country\",\"Company\",\"City\"]",
            "DF_BODY_TYPE_MAPPING": "'(timestamp as date, status as string, message as string, trace_id as string, items as (DELPHIX_COMPLIANCE_SERVICE_BATCH_ID as long, Website as string, Phone 2 as string, Phone 1 as string, Last Name as string, First Name as string, Email as string, Country as string, Company as string, City as string)[])'",
            "DF_TRIM_LENGTHS": "[-1,-1,-1,-1,-1,-1,-1,-1,-1]",
            "DF_FAIL_ON_NONCONFORMANT_DATA": true,
            "DF_TARGET_BATCH_SIZE": 2000,
            "DF_FIELD_DATE_FORMAT": "'{}'"
        },
        "datasetParameters": {
            "Source": {},
            "Sink": {}
        }
    },
    "staging": {},
    "compute": {
        "coreCount": 8,
        "computeType": "General"
    },
    "traceLevel": "None",
    "cacheSinks": {
        "firstRowOnly": true
    },
    "dataFlowDebugSessionId": "293a21c8-8e81-4390-985c-e320cc59236f",
    "continuationSettings": {
        "customizedCheckpointKey": "dcsazure_adls_to_adls_mask_pl-Perform Masking Per Table No Filter-92e1bac8-8bce-46f6-a80e-a8fb21ecba72"
    }
}
```
</details>


<details open>
<summary><h2> Solution </h2></summary>

To fix this issue in all of the pipeline we can add  a source transformation in the mask data flow that will normalize all the column names having spaces (by replacing with a placeholder) and then de-normalize it back to its original name when writing back to the sink. 

We add a new pipeline parameter `P_COLUMN_NAME_NORMALIZATION_PLACEHOLDER` with default value `__$__`. 
The dataflows will also have their own input parameter `DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER` whose value would be derived from the pipeline parameter. 

**Normalization step**
```
replace($$, ' ', $DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER)
```
**Denormalization step**
```
replace($$, $DF_COLUMN_NAME_NORMALIZATION_PLACEHOLDER, ' ')
```

We also need to take care of replacing the column names during parameter generation in the params dataflow(s) 
- Field Algorithm Assignments
- Body type mapping 
- Columns to mask 

</details>


<details>
<summary><h2> Testing Done </h2></summary>

Provide a clear description of how this change was tested. At minimum
this should include proof that a computer has executed the changed
lines. Ideally this should include an automated test or an explanation
as to why this pull request has no tests.
</details>