### PR TITLE
fix: remove references to `dbo` in metadata store migration scripts

### DIFF
--- a/dcsazure_ADLS_to_ADLS_delimited_discovery_pl/README.md
+++ b/dcsazure_ADLS_to_ADLS_delimited_discovery_pl/README.md
@@ -5,7 +5,7 @@ This pipeline will perform automated sensitive data discovery on your delimited 
 
 ### Prerequisites
 
-1. Configure the hosted metadata database and associated Azure SQL service (version `V2024.12.06.0`).
+1. Configure the hosted metadata database and associated Azure SQL service (version `V2025.01.15.0`).
 1. Configure the DCS for Azure REST service.
 1. Configure the Azure Data Lake Storage (Gen 2) service associated with your ADLS source data.
 

--- a/dcsazure_ADLS_to_ADLS_delimited_mask_pl/README.md
+++ b/dcsazure_ADLS_to_ADLS_delimited_mask_pl/README.md
@@ -5,7 +5,7 @@ This pipeline will perform masking of your delimited data from your Azure Data L
 
 ### Prerequisites
 
-1. Configure the hosted metadata database and associated Azure SQL service (version `V2024.12.06.0`+).
+1. Configure the hosted metadata database and associated Azure SQL service (version `V2025.01.15.0`+).
 1. Configure the DCS for Azure REST service.
 1. Configure the Azure Data Lake Storage service associated with your ADLS source data.
 1. Configure the Azure Data Lake Storage service associated with your ADLS sink data.

--- a/dcsazure_ADLS_to_ADLS_parquet_discovery_pl/README.md
+++ b/dcsazure_ADLS_to_ADLS_parquet_discovery_pl/README.md
@@ -5,7 +5,7 @@ This pipeline will perform automated sensitive data discovery on your parquet da
 
 ### Prerequisites
 
-1. Configure the hosted metadata database and associated Azure SQL service (version `V2024.12.06.0`).
+1. Configure the hosted metadata database and associated Azure SQL service (version `V2025.01.15.0`).
 1. Configure the DCS for Azure REST service.
 1. Configure the Azure Data Lake Storage (Gen 2) service associated with your ADLS source data.
 

--- a/dcsazure_ADLS_to_ADLS_parquet_mask_pl/README.md
+++ b/dcsazure_ADLS_to_ADLS_parquet_mask_pl/README.md
@@ -6,7 +6,7 @@ another.
 
 ### Prerequisites
 
-1. Configure the hosted metadata database and associated Azure SQL service (version `V2024.12.06.0`+).
+1. Configure the hosted metadata database and associated Azure SQL service (version `V2025.01.15.0`+).
 1. Configure the DCS for Azure REST service.
 1. Configure the Azure Data Lake Storage service associated with your ADLS source data.
 1. Configure the Azure Data Lake Storage service associated with your ADLS sink data.

--- a/dcsazure_AzureSQL_to_AzureSQL_discovery_pl/README.md
+++ b/dcsazure_AzureSQL_to_AzureSQL_discovery_pl/README.md
@@ -4,7 +4,7 @@
 This pipeline will perform automated sensitive data discovery on your AzureSQL Instance.
 
 ### Prerequisites
-1. Configure the hosted metadata database and associated Azure SQL service (version `V2024.10.24.0`+).
+1. Configure the hosted metadata database and associated Azure SQL service (version `V2025.01.15.0`+).
 1. Configure the DCS for Azure REST service.
 1. Configure the AzureSQL linked service.
 

--- a/dcsazure_Databricks_to_Databricks_discovery_pl/README.md
+++ b/dcsazure_Databricks_to_Databricks_discovery_pl/README.md
@@ -5,7 +5,7 @@ This pipeline will perform automated sensitive data discovery on your Databricks
 
 ### Prerequisites
 
-1. Configure the hosted metadata database and associated Azure SQL service (version `V2024.10.24.0`+).
+1. Configure the hosted metadata database and associated Azure SQL service (version `V2025.01.15.0`+).
 1. Configure the DCS for Azure REST service.
 1. Configure the Azure Data Lake Storage service associated with your Databricks source data.
 1. Configure the Azure Databricks Delta Lake service associated with your Databricks Deltalake source data.

--- a/dcsazure_Databricks_to_Databricks_mask_pl/README.md
+++ b/dcsazure_Databricks_to_Databricks_mask_pl/README.md
@@ -5,7 +5,7 @@ This pipeline will perform masking of data from your Databricks Delta Lake from 
 
 ### Prerequisites
 
-1. Configure the hosted metadata database and associated Azure SQL service (version `V2024.10.24.0`+).
+1. Configure the hosted metadata database and associated Azure SQL service (version `V2025.01.15.0`+).
 1. Configure the DCS for Azure REST service.
 1. Configure the Azure Data Lake Storage service associated with your Databricks source data.
 1. Configure the Azure Data Lake Storage service associated with your Databricks sink data (if required).

--- a/dcsazure_Snowflake_to_Snowflake_discovery_pl/README.md
+++ b/dcsazure_Snowflake_to_Snowflake_discovery_pl/README.md
@@ -4,7 +4,7 @@
 This pipeline will perform automated sensitive data discovery on your Snowflake Instance.
 
 ### Prerequisites
-1. Configure the hosted metadata database and associated Azure SQL service (version `V2024.10.24.0`+).
+1. Configure the hosted metadata database and associated Azure SQL service (version `V2025.01.15.0`+).
 1. Configure the DCS for Azure REST service.
 1. Configure the Snowflake linked service.
   * It is helpful for the linked service to be parameterized with the following parameters:

--- a/dcsazure_Snowflake_to_Snowflake_mask_pl/README.md
+++ b/dcsazure_Snowflake_to_Snowflake_mask_pl/README.md
@@ -4,7 +4,7 @@
 This pipeline will perform masking of your Snowflake Instance.
 
 ### Prerequisites
-1. Configure the hosted metadata database and associated Azure SQL service (version `V2024.10.24.0`+)
+1. Configure the hosted metadata database and associated Azure SQL service (version `V2025.01.15.0`+)
 1. Configure the DCS for Azure REST service.
 1. Configure the Snowflake linked service.
   * It is helpful for the linked service to be parameterized with the following parameters:

--- a/metadata_store_scripts/V2025.01.15.0__separate_algorithm_and_source_metadata.sql
+++ b/metadata_store_scripts/V2025.01.15.0__separate_algorithm_and_source_metadata.sql
@@ -1,21 +1,21 @@
-ALTER TABLE [dbo].[discovered_ruleset] ADD algorithm_metadata NVARCHAR(MAX);
+ALTER TABLE discovered_ruleset ADD algorithm_metadata NVARCHAR(MAX);
 
 -- Move the `date_format` key/value pair out of the metadata column and into the `algorithm_metadata` column
-UPDATE [dbo].[discovered_ruleset]
+UPDATE discovered_ruleset
 SET
     algorithm_metadata = JSON_MODIFY(COALESCE(algorithm_metadata,'{}'), '$.date_format', JSON_VALUE(metadata, '$.date_format')),
     metadata = JSON_MODIFY(metadata, '$.date_format', NULL)
 WHERE
     JSON_VALUE(metadata, '$.date_format') IS NOT NULL;
 -- Move the `key_column` key/value pair out of the metadata column and into the `algorithm_metadata` column
-UPDATE [dbo].[discovered_ruleset]
+UPDATE discovered_ruleset
 SET
     algorithm_metadata = JSON_MODIFY(COALESCE(algorithm_metadata,'{}'), '$.key_column', JSON_VALUE(metadata, '$.key_column')),
     metadata = JSON_MODIFY(metadata, '$.key_column', NULL)
 WHERE
     JSON_VALUE(metadata, '$.key_column') IS NOT NULL;
 -- Move the `conditions` key/value pair out of the metadata column and into the `algorithm_metadata` column
-UPDATE [dbo].[discovered_ruleset]
+UPDATE discovered_ruleset
 SET
     algorithm_metadata = JSON_MODIFY(COALESCE(algorithm_metadata,'{}'), '$.conditions', JSON_VALUE(metadata, '$.conditions')),
     metadata = JSON_MODIFY(metadata, '$.conditions', NULL)
@@ -23,7 +23,7 @@ WHERE
     JSON_VALUE(metadata, '$.conditions') IS NOT NULL;
 
 -- Rename the `metadata` column to `source_metadata` for clarity
-EXEC sp_rename 'dbo.discovered_ruleset.metadata', 'source_metadata', 'COLUMN';
+EXEC sp_rename 'discovered_ruleset.metadata', 'source_metadata', 'COLUMN';
 
 -- Update stored procedures to use new source_metadata column
 ALTER PROCEDURE get_columns_from_parquet_file_structure_sp

--- a/metadata_store_scripts/V2025.01.30.0__create_constraints_stored_procedure.sql
+++ b/metadata_store_scripts/V2025.01.30.0__create_constraints_stored_procedure.sql
@@ -51,7 +51,7 @@ BEGIN
                     sc.constraint_name
             ) AS row_num 
         FROM @source sc
-        INNER JOIN [dbo].[adf_data_mapping] dm
+        INNER JOIN adf_data_mapping dm
         ON (
             sc.dataset = dm.sink_dataset 
             AND sc.specified_database = dm.sink_database 

--- a/metadata_store_scripts/bootstrap.sql
+++ b/metadata_store_scripts/bootstrap.sql
@@ -7,7 +7,7 @@
 -- * V2024.12.02.0__add_azuresql_to_azuresql_support
 -- * V2024.12.13.0__create_create_constraints_table
 -- * V2024.12.26.0__add_adls_to_adls_parquet_support
--- * V20205.01.15.0__separate_algorithm_and_source_metadata
+-- * V2025.01.15.0__separate_algorithm_and_source_metadata
 -- * V2025.01.30.0__create_constraints_stored_procedure
 -- The contents of each of those files follows
 
@@ -836,25 +836,25 @@ WHERE sink_dataset = 'ADLS';
 -- END: Rename the ADLS dataset to ADLS-DELIMITED to avoid confusion
 
 
--- source: V20205.01.15.0__separate_algorithm_and_source_metadata
-ALTER TABLE [dbo].[discovered_ruleset] ADD algorithm_metadata NVARCHAR(MAX);
+-- source: V2025.01.15.0__separate_algorithm_and_source_metadata
+ALTER TABLE discovered_ruleset ADD algorithm_metadata NVARCHAR(MAX);
 
 -- Move the `date_format` key/value pair out of the metadata column and into the `algorithm_metadata` column
-UPDATE [dbo].[discovered_ruleset]
+UPDATE discovered_ruleset
 SET
     algorithm_metadata = JSON_MODIFY(COALESCE(algorithm_metadata,'{}'), '$.date_format', JSON_VALUE(metadata, '$.date_format')),
     metadata = JSON_MODIFY(metadata, '$.date_format', NULL)
 WHERE
     JSON_VALUE(metadata, '$.date_format') IS NOT NULL;
 -- Move the `key_column` key/value pair out of the metadata column and into the `algorithm_metadata` column
-UPDATE [dbo].[discovered_ruleset]
+UPDATE discovered_ruleset
 SET
     algorithm_metadata = JSON_MODIFY(COALESCE(algorithm_metadata,'{}'), '$.key_column', JSON_VALUE(metadata, '$.key_column')),
     metadata = JSON_MODIFY(metadata, '$.key_column', NULL)
 WHERE
     JSON_VALUE(metadata, '$.key_column') IS NOT NULL;
 -- Move the `conditions` key/value pair out of the metadata column and into the `algorithm_metadata` column
-UPDATE [dbo].[discovered_ruleset]
+UPDATE discovered_ruleset
 SET
     algorithm_metadata = JSON_MODIFY(COALESCE(algorithm_metadata,'{}'), '$.conditions', JSON_VALUE(metadata, '$.conditions')),
     metadata = JSON_MODIFY(metadata, '$.conditions', NULL)
@@ -862,7 +862,7 @@ WHERE
     JSON_VALUE(metadata, '$.conditions') IS NOT NULL;
 
 -- Rename the `metadata` column to `source_metadata` for clarity
-EXEC sp_rename 'dbo.discovered_ruleset.metadata', 'source_metadata', 'COLUMN';
+EXEC sp_rename 'discovered_ruleset.metadata', 'source_metadata', 'COLUMN';
 
 -- Update stored procedures to use new source_metadata column
 ALTER PROCEDURE get_columns_from_parquet_file_structure_sp
@@ -1091,7 +1091,7 @@ BEGIN
                     sc.constraint_name
             ) AS row_num 
         FROM @source sc
-        INNER JOIN [dbo].[adf_data_mapping] dm
+        INNER JOIN adf_data_mapping dm
         ON (
             sc.dataset = dm.sink_dataset 
             AND sc.specified_database = dm.sink_database 

--- a/scripts/migrations.sh
+++ b/scripts/migrations.sh
@@ -5,6 +5,11 @@ for MIGRATION in $(ls metadata_store_scripts/V*.sql)
 do
   script_version_and_comment=( $(basename -- "$MIGRATION" .sql ) )
   echo "$script_version_and_comment"
+  use_of_dbo=( $(grep "dbo" $MIGRATION | wc -l ) )
+  if [[ $use_of_dbo -ne 0 ]]; then
+    echo "Please remove reference to dbo in migration script"
+    exit -1
+  fi
   lines_in_bootstrap=( $(grep "$script_version_and_comment" metadata_store_scripts/bootstrap.sql | wc -l) )
   if [[ $lines_in_bootstrap -eq 2 ]]; then
     # Nothing to do, assume this is correct
@@ -16,6 +21,7 @@ do
     cat $MIGRATION >> metadata_store_scripts/bootstrap.sql.tmp
     echo "" >> metadata_store_scripts/bootstrap.sql.tmp
     mv metadata_store_scripts/bootstrap.sql.tmp metadata_store_scripts/bootstrap.sql
+    echo "[REMINDER] It appears as though this migration was added, please update the README.md associated with impacted pipelines"
   else
     echo "$script_version_and_comment not properly configured in bootstrap.sql"
     exit -1


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

References to `dbo` in the migration scripts assumes that the database schema is `dbo`, when it may not be. In fact, `dbo` may be reserved and unavailable to some users.

We should not have hard-coded values of `dbo` in our migration scripts.
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Remove existing references to `dbo` in the metadata store scripts.
Provide a check to prevent this from happening again when using the `scripts/migrations.sh` utility.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

Ran updated migration script.
Ran updated queries to confirm they work without specifying `dbo`.
Added a test migration and re-ran updated migration script.
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<details open>
<summary><h2> Bonus </h2></summary>

* Updated individual pipeline READMEs to refer to the required metadata version (as this was previously missed).
* Added a reminder to the printout when running `scrips/migrations.sh` to hopefully prevent this from happening again.
* Correct DB migration versioning
</details>