### PR TITLE
chore: Add pre-commit hook to validate Changelog.md

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  - repo: local
+    hooks:
+      - id: changelog_verify
+        name: Verify if CHANGELOG.md has been updated
+        entry: python ./scripts/pre-commit/validate_changelog_update.py
+        language: python
+        always_run: true
+        pass_filenames: false
+        verbose: true
+        additional_dependencies:
+          - PyYAML

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+#
+# Copyright (c) 2025 by Delphix. All rights reserved.
+#
+
 repos:
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 repos:
   - repo: local
     hooks:
-      - id: changelog_verify
+      - id: validate-changelog
         name: Verify if CHANGELOG.md has been updated
-        entry: python ./scripts/pre-commit/validate_changelog_update.py
+        entry: python ./scripts/pre-commit/validate_changelog.py
         language: python
         always_run: true
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,4 @@ repos:
         verbose: true
         additional_dependencies:
           - PyYAML
+          - packaging

--- a/scripts/pre-commit/validate_changelog.py
+++ b/scripts/pre-commit/validate_changelog.py
@@ -1,3 +1,7 @@
+#
+# Copyright (c) 2025 by Delphix. All rights reserved.
+#
+
 import subprocess
 import logging
 import re
@@ -5,18 +9,13 @@ import sys
 import typing as tp
 from pathlib import Path
 
-logger = logging.getLogger("validate_changelog_update")
-logger.setLevel(logging.INFO)
-
-handler = logging.StreamHandler()
-handler.setLevel(logging.INFO)
-formatter = logging.Formatter("%(levelname)s - %(message)s")
-handler.setFormatter(formatter)
-logger.addHandler(handler)
+logging.basicConfig(level=logging.INFO, format="%(levelname)s - %(message)s")
+logger = logging.getLogger("validate_changelog")
 
 CODE_EXTENSIONS = {".json", ".sql"}
 VERSION_FILE = "VERSION.md"
 CHANGELOG_FILE = "CHANGELOG.md"
+MAX_LINES_TO_READ = 10
 
 
 class ValidationError(Exception):
@@ -50,7 +49,7 @@ def read_version_file() -> str:
 def read_changelog_file() -> tp.Optional[str]:
     changelog_path = get_project_root() / CHANGELOG_FILE
     with changelog_path.open("r") as file:
-        content = ''.join([next(file) for _ in range(10)])
+        content = ''.join([next(file) for _ in range(MAX_LINES_TO_READ)])
     match = re.search(r"^#\s*\[?(\d+\.\d+\.\d+)]?", content, re.MULTILINE)
     return match.group(1) if match else None
 

--- a/scripts/pre-commit/validate_changelog.py
+++ b/scripts/pre-commit/validate_changelog.py
@@ -38,7 +38,7 @@ def get_project_root() -> Path:
 
 
 def read_file_content(file_path: Path) -> str:
-    if not file_path.is_file():
+    if not file_path.exists():
         raise ValidationError(f"File not found: {file_path}")
     return file_path.read_text().strip()
 
@@ -49,7 +49,8 @@ def read_version_file() -> str:
 
 def read_changelog_file() -> tp.Optional[str]:
     changelog_path = get_project_root() / CHANGELOG_FILE
-    content = changelog_path.read_text()
+    with changelog_path.open("r") as file:
+        content = ''.join([next(file) for _ in range(10)])
     match = re.search(r"^#\s*\[?(\d+\.\d+\.\d+)]?", content, re.MULTILINE)
     return match.group(1) if match else None
 

--- a/scripts/pre-commit/validate_changelog_update.py
+++ b/scripts/pre-commit/validate_changelog_update.py
@@ -1,0 +1,118 @@
+import subprocess
+import logging
+import re
+import sys
+import typing as tp
+from pathlib import Path
+
+logger = logging.getLogger("validate_changelog_update")
+logger.setLevel(logging.INFO)
+
+handler = logging.StreamHandler()
+handler.setLevel(logging.INFO)
+formatter = logging.Formatter("%(levelname)s - %(message)s")
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+
+CODE_EXTENSIONS = {".json", ".sql"}
+VERSION_FILE = "VERSION.md"
+CHANGELOG_FILE = "CHANGELOG.md"
+
+
+class ValidationError(Exception):
+    """Custom exception for validation-related errors."""
+
+
+def is_code_file(filepath: str) -> bool:
+    return Path(filepath).suffix in CODE_EXTENSIONS
+
+
+def get_project_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True
+    )
+    return Path(result.stdout.strip())
+
+
+def read_file_content(file_path: Path) -> str:
+    if not file_path.is_file():
+        raise ValidationError(f"File not found: {file_path}")
+    return file_path.read_text().strip()
+
+
+def read_version_file() -> str:
+    return read_file_content(get_project_root() / VERSION_FILE)
+
+
+def read_changelog_file() -> tp.Optional[str]:
+    changelog_path = get_project_root() / CHANGELOG_FILE
+    content = changelog_path.read_text()
+    match = re.search(r"^#\s*\[?(\d+\.\d+\.\d+)]?", content, re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def get_changed_files() -> tp.List[str]:
+    output = subprocess.check_output(
+        [
+            "git", "diff", "--no-merges", "--name-only",
+            "--first-parent", "origin/main"
+        ],
+        text=True
+    )
+    return output.splitlines()
+
+
+def validate_files(changed_files: tp.List[str]) -> None:
+    staged_code = any(is_code_file(file) for file in changed_files)
+    changelog_updated = CHANGELOG_FILE in changed_files
+
+    if not staged_code and not changelog_updated:
+        return
+
+    if staged_code and not changelog_updated:
+        raise ValidationError(
+            f"Detected code changes, but no corresponding update to {CHANGELOG_FILE}."
+            " Please document your changes in the changelog to maintain proper release history."
+        )
+
+    if changelog_updated and not staged_code:
+        raise ValidationError(
+            f"{CHANGELOG_FILE} has been modified, but no code files were changed."
+            " If this was unintentional, please remove the changelog update."
+        )
+
+    version = read_version_file()
+    if not version:
+        raise ValidationError(f"Could not determine version from {VERSION_FILE}")
+
+    changelog_version = read_changelog_file()
+    if not changelog_version:
+        raise ValidationError(f"Could not determine version from {CHANGELOG_FILE}")
+
+    if version != changelog_version:
+        raise ValidationError(
+            f"Version mismatch:  {VERSION_FILE}: {version},  {CHANGELOG_FILE}: {changelog_version}"
+        )
+
+
+def main():
+    try:
+        changed_files = get_changed_files()
+        validate_files(changed_files)
+        return 0
+
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Git command failed: {e}")
+    except ValidationError as e:
+        logger.error(f"Validation failed: {e}")
+    except Exception as e:
+        logger.error(f"Unexpected error: {e}")
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pre-commit/validate_changelog_update.py
+++ b/scripts/pre-commit/validate_changelog_update.py
@@ -75,7 +75,7 @@ def validate_files(changed_files: tp.List[str]) -> None:
     if staged_code and not changelog_updated:
         raise ValidationError(
             f"Detected code changes, but no corresponding update to {CHANGELOG_FILE}."
-            " Please document your changes in the changelog to maintain proper release history."
+            " Please document your changes to maintain release history."
         )
 
     if changelog_updated and not staged_code:


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

We need to add pre-commit checks in the repo to avoid manual verification of basic repo change rules.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

1. Ensure the changelog is updated with the latest changes in the new pull request (PR).
2. Confirm that the new version in the changelog matches the version specified in the VERSION file.
3. Automation: Implement a pre-commit hook to verify that the changelog adheres to the above rules.

</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

I've added a .pre-commit-config.yaml file to the repository's root. The first hook in the configuration performs several checks on the CHANGELOG.md file:
1. Verifies whether CHANGELOG.md has been updated when code changes are made.
2. Determines whether an update to CHANGELOG.md was necessary.
3. Ensures that the latest version number in CHANGELOG.md matches the one in VERSION.md.


</details>


<details>
<summary><h2> Testing Done </h2></summary>

1. No code changes
```
APAC-SHARAD:dcs-for-azure-templates sharad.pandey$ git lint
Running checks locally...
Exec: /Users/sharad.pandey/Code/git-utils-github/git-utils/bin/pre-commit run --color=always --from-ref=refs/remotes/origin/main --to-ref=a75daae1e8e296d504d56326ed37409557eb3612 --all-files
    : Verify if CHANGELOG.md has been updated..................................Passed
    : - hook id: changelog_verify
    : - duration: 0.07s
Pass: /Users/sharad.pandey/Code/git-utils-github/git-utils/bin/pre-commit run --color=always --from-ref=refs/remotes/origin/main --to-ref=a75daae1e8e296d504d56326ed37409557eb3612 --all-files
```


2. Code changes done, but CHANGELOG.md file not updated
```
APAC-SHARAD:dcs-for-azure-templates sharad.pandey$ git lint
Running checks locally...
Exec: /Users/sharad.pandey/Code/git-utils-github/git-utils/bin/pre-commit run --color=always --from-ref=refs/remotes/origin/main --to-ref=a75daae1e8e296d504d56326ed37409557eb3612 --all-files
    : Verify if CHANGELOG.md has been updated..................................Failed
    : - hook id: changelog_verify
    : - duration: 0.04s
    : - exit code: 1
    : 
    : ERROR - Validation failed: Detected code changes, but no corresponding update to CHANGELOG.md. Please document your changes in the changelog to maintain proper release history.
    : 
Fail: /Users/sharad.pandey/Code/git-utils-github/git-utils/bin/pre-commit run --color=always --from-ref=refs/remotes/origin/main --to-ref=a75daae1e8e296d504d56326ed37409557eb3612 --all-files - (1)
```



3. Code changes were not done, but CHANGELOG.md file was updated
```
APAC-SHARAD:dcs-for-azure-templates sharad.pandey$ git lint
Running checks locally...
Exec: /Users/sharad.pandey/Code/git-utils-github/git-utils/bin/pre-commit run --color=always --from-ref=refs/remotes/origin/main --to-ref=a75daae1e8e296d504d56326ed37409557eb3612 --all-files
    : Verify if CHANGELOG.md has been updated..................................Failed
    : - hook id: changelog_verify
    : - duration: 0.04s
    : - exit code: 1
    : 
    : ERROR - Validation failed: CHANGELOG.md has been modified, but no code files were changed. If this was unintentional, please remove the changelog update.
    : 
Fail: /Users/sharad.pandey/Code/git-utils-github/git-utils/bin/pre-commit run --color=always --from-ref=refs/remotes/origin/main --to-ref=a75daae1e8e296d504d56326ed37409557eb3612 --all-files - (1)
```


4. Latest version is different in VERSION.md file and CHANGELOG.md file
```
APAC-SHARAD:dcs-for-azure-templates sharad.pandey$ git lint
Running checks locally...
Exec: /Users/sharad.pandey/Code/git-utils-github/git-utils/bin/pre-commit run --color=always --from-ref=refs/remotes/origin/main --to-ref=a75daae1e8e296d504d56326ed37409557eb3612 --all-files
    : Verify if CHANGELOG.md has been updated..................................Failed
    : - hook id: changelog_verify
    : - duration: 0.06s
    : - exit code: 1
    : 
    : ERROR - Validation failed: Version mismatch:  VERSION.md: 0.0.24,  CHANGELOG.md: 0.0.22
    : 
Fail: /Users/sharad.pandey/Code/git-utils-github/git-utils/bin/pre-commit run --color=always --from-ref=refs/remotes/origin/main --to-ref=a75daae1e8e296d504d56326ed37409557eb3612 --all-files - (1)
```

Positive test case, code was changed, version file was updated and CHANGELOG.md file was also updated
```
APAC-SHARAD:dcs-for-azure-templates sharad.pandey$ git lint
Running checks locally...
Exec: /Users/sharad.pandey/Code/git-utils-github/git-utils/bin/pre-commit run --color=always --from-ref=refs/remotes/origin/main --to-ref=a75daae1e8e296d504d56326ed37409557eb3612 --all-files
    : Verify if CHANGELOG.md has been updated..................................Passed
    : - hook id: changelog_verify
    : - duration: 0.06s
Pass: /Users/sharad.pandey/Code/git-utils-github/git-utils/bin/pre-commit run --color=always --from-ref=refs/remotes/origin/main --to-ref=a75daae1e8e296d504d56326ed37409557eb3612 --all-files

```
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
